### PR TITLE
Added new date format regex: YYYY/M/D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage/
 node_modules/
 
 npm-debug.log
+.idea

--- a/src/time-regex.js
+++ b/src/time-regex.js
@@ -121,6 +121,7 @@ var Do = '\\d{1,2}(st|nd|rd|th)';
 
 var dateFormatRegexStrings = [
   YYYY + '-' + M + '-' + D,
+  YYYY + '\\/' + M + '\\/' + D,
   M + '\\/' + D + '\\/' + YYYY,
   MMMM + ' ' + DD + ', ' + YYYY,
   MMM + ' ' + DD + ', ' + YYYY,
@@ -129,6 +130,7 @@ var dateFormatRegexStrings = [
 ];
 var dateFormatStrings = [
   'YYYY-M-D',
+  'YYYY/M/D',
   'M/D/YYYY',
   'MMMM DD, YYYY',
   'MMM DD, YYYY',

--- a/test/time-validation-test.js
+++ b/test/time-validation-test.js
@@ -23,6 +23,7 @@
 var test = require('./test-utils').test;
 
 var whichFormatDate = require('../src/utils').whichFormatDate;
+var whichFormatDateTime = require('../src/utils').whichFormatDateTime;
 
 test('#whichFormatDate', function t(assert) {
   assert.equals(whichFormatDate('2015-1-1'), 'YYYY-M-D');
@@ -33,5 +34,10 @@ test('#whichFormatDate', function t(assert) {
   assert.equals(whichFormatDate('January 3rd, 2012'), 'MMMM Do, YYYY');
   assert.equals(whichFormatDate('Jan 2nd, 2012'), 'MMM Do, YYYY');
   assert.equals(whichFormatDate('Jan 22nd, 2012'), 'MMM Do, YYYY');
+  assert.end();
+});
+
+test('#whichFormatDateTime', function t(assert) {
+  assert.equals(whichFormatDateTime('1967/07/19 20:49:08.07'), 'YYYY/M/D HH:mm:ss.SSSS');
   assert.end();
 });


### PR DESCRIPTION
I added a new format for date:

YYYY/M/D

This is necessary for public datasets that we are currently analyzing for kepler.gl lunch!

Added a test to validate the new functionality!