### PR TITLE
Better handling for nulls and empty columns

### DIFF
--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -37,6 +37,12 @@ var VALIDATOR_CONSIDERS_EMPTY_STRING_NULL = {
   NUMBER: true
 };
 
+var VALIDATOR_CONSIDERS_NAN_NULL = {
+  INT: true,
+  NUMBER: true,
+  FLOAT: true
+};
+
 /**
  * Check if a given value is a null for a validator
  * @param {String} value - value to be checked if null
@@ -49,6 +55,10 @@ function valueIsNullForValidator(value, validatorName) {
     value === CONSTANT.NULL ||
     typeof value === 'undefined'
   ) {
+    return true;
+  }
+
+  if (Number.isNaN(value) && VALIDATOR_CONSIDERS_NAN_NULL[validatorName]) {
     return true;
   }
 

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -53,6 +53,7 @@ function valueIsNullForValidator(value, validatorName) {
   if (
     value === null ||
     value === CONSTANT.NULL ||
+    value === CONSTANT.DB_NULL ||
     typeof value === 'undefined'
   ) {
     return true;

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -135,8 +135,8 @@ Analyzer.computeColMeta = function computeColMeta(
 ) {
   options = options || {};
   var ignoredDataTypes = options.ignoredDataTypes || [];
-  var dropUnknowns = options.dropUnknowns;
-  var maybePushUnknown = dropUnknowns ? _noop : _pushIntoArr;
+  var keepUnknowns = options.keepUnknowns;
+  var maybePushUnknown = keepUnknowns ? _pushIntoArr : _noop;
   var allValidators = CONSTANT.VALIDATORS.filter(function filterValidators(
     validator
   ) {

--- a/src/constant.js
+++ b/src/constant.js
@@ -61,6 +61,8 @@ var CONSTANT = {
   BOOLEAN_TRUE_VALUES: ['true', 'yes'],
   BOOLEAN_FALSE_VALUES: ['false', 'no'],
 
+  // Common in databases like MySQL: https://dev.mysql.com/doc/refman/8.0/en/null-values.html
+  DB_NULL: '\\N',
   NULL: 'NULL'
 };
 

--- a/test/basic-types-test.js
+++ b/test/basic-types-test.js
@@ -291,5 +291,27 @@ test('Analyzer: string validator', function t(assert) {
     );
   });
 
+  arr = ['\\N', '\\N', '\\N', '\\N', '\\N'].map(mapArr);
+  assert.equal(
+    Analyzer.computeColMeta(arr)[0].type,
+    'STRING',
+    'Interprets as a string'
+  );
+
+  assert.end();
+});
+
+test('Analyzer: handling of unknown types', function t(assert) {
+  var arr = [];
+
+  ['', null, undefined, ''].forEach(function loopAcrossExamples(ex) {
+    arr = [ex, ex, ex, ex, ex, ex].map(mapArr);
+    assert.equal(
+      Analyzer.computeColMeta(arr, [], {ignoredDataTypes: 'CITY'})[0].type,
+      'STRING',
+      'Interprets ' + ex + ' as a string'
+    );
+  });
+
   assert.end();
 });

--- a/test/basic-types-test.js
+++ b/test/basic-types-test.js
@@ -293,7 +293,7 @@ test('Analyzer: string validator', function t(assert) {
 
   arr = ['\\N', '\\N', '\\N', '\\N', '\\N'].map(mapArr);
   assert.equal(
-    Analyzer.computeColMeta(arr)[0].type,
+    Analyzer.computeColMeta(arr, [], {keepUnknowns: true})[0].type,
     'STRING',
     'Interprets as a string'
   );
@@ -307,7 +307,9 @@ test('Analyzer: handling of unknown types', function t(assert) {
   ['', null, undefined, ''].forEach(function loopAcrossExamples(ex) {
     arr = [ex, ex, ex, ex, ex, ex].map(mapArr);
     assert.equal(
-      Analyzer.computeColMeta(arr, [], {ignoredDataTypes: 'CITY'})[0].type,
+      Analyzer.computeColMeta(arr, [], {
+        keepUnknowns: true
+      })[0].type,
       'STRING',
       'Interprets ' + ex + ' as a string'
     );

--- a/test/basic-types-test.js
+++ b/test/basic-types-test.js
@@ -81,7 +81,9 @@ test('Analyzer: boolean validator', function t(assert) {
 test('Analyzer: array validator', function t(assert) {
   var arr = [];
 
-  arr = [[1,2,3], [4,5,6], [7,8,9], ['1', 'b'], ['2', 3], ['he']].map(mapArr);
+  arr = [[1, 2, 3], [4, 5, 6], [7, 8, 9], ['1', 'b'], ['2', 3], ['he']].map(
+    mapArr
+  );
   assert.equal(
     Analyzer.computeColMeta(arr)[0].type,
     'ARRAY',
@@ -94,7 +96,7 @@ test('Analyzer: array validator', function t(assert) {
 test('Analyzer: object validator', function t(assert) {
   var arr = [];
 
-  arr = [{a: 1}, [4,5,6], {b: 2}, {c: 3}, {d: 4}, {d: 5}].map(mapArr);
+  arr = [{a: 1}, [4, 5, 6], {b: 2}, {c: 3}, {d: 4}, {d: 5}].map(mapArr);
   assert.equal(
     Analyzer.computeColMeta(arr)[0].type,
     'OBJECT',
@@ -114,6 +116,13 @@ test('Analyzer: number validator', function t(assert) {
     'Inteprets values as integers'
   );
 
+  arr = [NaN, NaN, NaN, 1, '222,222', '-333,333,333', -4, '+5,000'].map(mapArr);
+  assert.equal(
+    Analyzer.computeColMeta(arr)[0].type,
+    'INT',
+    'Treats NaNs as nulls and inteprets values as integer'
+  );
+
   arr = ['-.1111', '+.2', '+3,333.3333', 444.4444, '5,555,555.5'].map(mapArr);
   assert.equal(
     Analyzer.computeColMeta(arr)[0].type,
@@ -122,13 +131,37 @@ test('Analyzer: number validator', function t(assert) {
   );
 
   arr = [
-    1, '222,222', '-333,333,333', -4, '+5,000',
-    '-.1111', '+.2', '+3,333.3333', 444.4444, '5,555,555.5'
+    1,
+    '222,222',
+    '-333,333,333',
+    -4,
+    '+5,000',
+    '-.1111',
+    '+.2',
+    '+3,333.3333',
+    444.4444,
+    '5,555,555.5'
   ].map(mapArr);
   assert.equal(
     Analyzer.computeColMeta(arr)[0].type,
     'FLOAT',
     'Inteprets a mix of int and float values as floats'
+  );
+
+  arr = [
+    NaN,
+    NaN,
+    NaN,
+    '-.1111',
+    '+.2',
+    '+3,333.3333',
+    444.4444,
+    '5,555,555.5'
+  ].map(mapArr);
+  assert.equal(
+    Analyzer.computeColMeta(arr)[0].type,
+    'FLOAT',
+    'Treats NaNs as nulls still inteprets values as floats'
   );
 
   arr = ['$1', '$0.12', '$1.12', '$1,000.12', '$1,000.12'].map(mapArr);
@@ -157,9 +190,9 @@ test('Analyzer: number validator', function t(assert) {
       assert.equal(
         Analyzer.computeColMeta(arr)[0].category,
         'MEASURE',
-        'Inteprets sci or money valeus, eg '
-        + ex +
-        ' formatted values as numbers'
+        'Inteprets sci or money valeus, eg ' +
+          ex +
+          ' formatted values as numbers'
       );
     }
   );
@@ -180,9 +213,20 @@ test('Analyzer: number validator', function t(assert) {
   );
 
   arr = [
-    1, '222,222', '-333,333,333', -4, '+5,000',
-    '-.1111', '+.2', '+3,333.3333', 444.4444, '5,555,555.5',
-    '182891173641581479', '2e53', '1e16', 182891173641581479
+    1,
+    '222,222',
+    '-333,333,333',
+    -4,
+    '+5,000',
+    '-.1111',
+    '+.2',
+    '+3,333.3333',
+    444.4444,
+    '5,555,555.5',
+    '182891173641581479',
+    '2e53',
+    '1e16',
+    182891173641581479
   ].map(mapArr);
   assert.equal(
     Analyzer.computeColMeta(arr)[0].type,

--- a/test/basic-types-test.js
+++ b/test/basic-types-test.js
@@ -17,6 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+/* eslint-disable max-statements */
 
 'use strict';
 
@@ -182,6 +183,22 @@ test('Analyzer: number validator', function t(assert) {
     Analyzer.computeColMeta(arr)[0].type,
     'PERCENT',
     'Inteprets values as percents'
+  );
+
+  arr = [
+    '\\N',
+    '\\N',
+    '\\N',
+    '10.12345%',
+    '-10.222%',
+    '+1,000.33%',
+    '10.4%',
+    '10.55%'
+  ].map(mapArr);
+  assert.equal(
+    Analyzer.computeColMeta(arr)[0].type,
+    'PERCENT',
+    'Ignore database nulls, and inteprets values as percents'
   );
 
   [2.3, '+4,000', '-5,023.234', '2.3e+2', '$23,203', '23.45%'].forEach(

--- a/test/geo-test.js
+++ b/test/geo-test.js
@@ -81,14 +81,25 @@ test('Analyzer: Geo check', function t(assert) {
     {
       col1: {
         type: 'LineString',
-        coordinates: [[102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]]
+        coordinates: [
+          [102.0, 0.0],
+          [103.0, 1.0],
+          [104.0, 0.0],
+          [105.0, 1.0]
+        ]
       }
     },
     {
       col1: {
         type: 'Polygon',
         coordinates: [
-          [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]
+          [
+            [100.0, 0.0],
+            [101.0, 0.0],
+            [101.0, 1.0],
+            [100.0, 1.0],
+            [100.0, 0.0]
+          ]
         ]
       }
     }
@@ -140,7 +151,7 @@ test('Analyzer: geo from string validator', function t(assert) {
     assert.equal(
       Analyzer.computeColMeta(arr)[0].geoType,
       expectedType,
-      `correctly indentifies ${  expectedType  } as WKT ${  expectedType  }s`
+      `correctly indentifies ${expectedType} as WKT ${expectedType}s`
     );
   });
 
@@ -248,7 +259,9 @@ test('Analyzer: nulls', function t(assert) {
     {regex: /c/, dataType: 'DATETIME'},
     {regex: /d/, dataType: 'GEOMETRY_FROM_STRING'}
   ];
-  var analyzed = Analyzer.computeColMeta(nullExample, rules);
+  var analyzed = Analyzer.computeColMeta(nullExample, rules, {
+    dropUnknowns: true
+  });
   assert.deepEqual(analyzed, known, 'Analyzer handles null data well');
 
   var newCoordData = [];
@@ -268,6 +281,45 @@ test('Analyzer: nulls', function t(assert) {
     ],
     'Handles conditional nulls well'
   );
+  assert.end();
+});
+
+test('Analyzer: nulls without dropping unknowns, and just intepreting as string', function t(assert) {
+  var nullExample = [
+    {a: '2016-11-04 12:43:36.711458', b: null, c: null, d: null},
+    {a: '2016-11-04 12:43:36.711458', b: null, c: null, d: null},
+    {a: '2016-11-04 12:43:36.711458', b: null, c: null, d: null},
+    {a: '2016-11-04 12:43:36.711458', b: null, c: null, d: null},
+    {a: '2016-11-04 12:43:36.711458', b: 1.2, c: null, d: null},
+    {a: '2016-11-04 12:43:36.711458', b: null, c: null, d: null},
+    {a: '2016-11-04 12:43:36.711458', b: null, c: null, d: null},
+    {a: '2016-11-04 12:43:36.711458', b: null, c: null, d: null}
+  ];
+
+  var known = [
+    {
+      category: 'TIME',
+      format: 'YYYY-M-D HH:mm:ss.SSSS',
+      key: 'a',
+      label: 'a',
+      type: 'DATETIME'
+    },
+    {category: 'MEASURE', format: '', key: 'b', label: 'b', type: 'FLOAT'},
+    {category: 'TIME', format: '', key: 'c', label: 'c', type: 'DATETIME'},
+    {
+      category: 'GEOMETRY',
+      format: '',
+      key: 'd',
+      label: 'd',
+      type: 'GEOMETRY_FROM_STRING'
+    }
+  ];
+  var rules = [
+    {regex: /c/, dataType: 'DATETIME'},
+    {regex: /d/, dataType: 'GEOMETRY_FROM_STRING'}
+  ];
+  var analyzed = Analyzer.computeColMeta(nullExample, rules);
+  assert.deepEqual(analyzed, known, 'Analyzer handles null data well');
   assert.end();
 });
 

--- a/test/geo-test.js
+++ b/test/geo-test.js
@@ -259,9 +259,7 @@ test('Analyzer: nulls', function t(assert) {
     {regex: /c/, dataType: 'DATETIME'},
     {regex: /d/, dataType: 'GEOMETRY_FROM_STRING'}
   ];
-  var analyzed = Analyzer.computeColMeta(nullExample, rules, {
-    dropUnknowns: true
-  });
+  var analyzed = Analyzer.computeColMeta(nullExample, rules);
   assert.deepEqual(analyzed, known, 'Analyzer handles null data well');
 
   var newCoordData = [];
@@ -318,7 +316,9 @@ test('Analyzer: nulls without dropping unknowns, and just intepreting as string'
     {regex: /c/, dataType: 'DATETIME'},
     {regex: /d/, dataType: 'GEOMETRY_FROM_STRING'}
   ];
-  var analyzed = Analyzer.computeColMeta(nullExample, rules);
+  var analyzed = Analyzer.computeColMeta(nullExample, rules, {
+    keepUnknowns: true
+  });
   assert.deepEqual(analyzed, known, 'Analyzer handles null data well');
   assert.end();
 });


### PR DESCRIPTION
This ports several fixes from the internal Uber version of `type-analyzer` (and should allow us to deprecate the internal lib).

- Improve handling for `NaN` and common database null syntax `"\N"`

- Support `options.keepUnknowns` to avoid dropping columns with unknown types