### PR TITLE
FEAT: Support date objects as inputs

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -48,6 +48,7 @@ var CONSTANT = {
     // object format
     NONE: 'NONE',
     ARRAY: 'ARRAY',
+    DATE_OBJECT: 'DATE_OBJECT',
     OBJECT: 'OBJECT'
   },
 
@@ -118,6 +119,7 @@ CONSTANT.VALIDATORS = [
   // true/false, 0/1
   CONSTANT.DATA_TYPES.BOOLEAN,
   CONSTANT.DATA_TYPES.ARRAY,
+  CONSTANT.DATA_TYPES.DATE_OBJECT,
   CONSTANT.DATA_TYPES.OBJECT,
 
   // prefix/postfix rules

--- a/src/utils.js
+++ b/src/utils.js
@@ -100,6 +100,11 @@ var Utils = {
     return Array.isArray(value);
   },
 
+  isDateObject: function isDateObject(value) {
+    // Note: invalid Dates return true as well as valid Dates.
+    return value instanceof Date;
+  },
+
   isObject: function isObject(value) {
     return value === Object(value) && typeof value !== 'function' && !Array.isArray(value)
   },

--- a/src/validator-map.js
+++ b/src/validator-map.js
@@ -36,6 +36,7 @@ VALIDATOR_MAP[DATA_TYPES.PAIR_GEOMETRY_FROM_STRING] =
 // basic boolean: true/false, 0/1
 VALIDATOR_MAP[DATA_TYPES.BOOLEAN] = Utils.isBoolean;
 VALIDATOR_MAP[DATA_TYPES.ARRAY] = Utils.isArray;
+VALIDATOR_MAP[DATA_TYPES.DATE_OBJECT] = Utils.isDateObject;
 VALIDATOR_MAP[DATA_TYPES.OBJECT] = Utils.isObject;
 
 // prefix/postfix rules: '$30.00', '10.05%'

--- a/test/time-test.js
+++ b/test/time-test.js
@@ -134,6 +134,30 @@ test('Analyzer: date validator', function t(assert) {
   result = Analyzer.computeColMeta(arr);
   assert.equal(result[0].type, 'DATETIME', 'Interprets col as datetime correctly');
 
+  arr = [
+    {col: new Date(2016, 1, 1)},
+    {col: new Date(2017, 2, 2)},
+    {col: new Date(2018, 3, 3)}
+  ];
+  result = Analyzer.computeColMeta(arr);
+  assert.equal(result[0].type, 'DATE_OBJECT', 'Interprets valid Dates created w/ component ctor as date objects');
+
+  arr = [
+    {col: new Date('2016-07-24T19:53:38.000Z')},
+    {col: new Date('2016-07-24T12:55:36.000Z')},
+    {col: new Date('2016-07-24T19:55:36.000Z')}
+  ];
+  result = Analyzer.computeColMeta(arr);
+  assert.equal(result[0].type, 'DATE_OBJECT', 'Interprets valid Dates created w/ timestamp ctor as date objects');
+
+  arr = [
+    {col: new Date('this is')},
+    {col: new Date('not a')},
+    {col: new Date('valid date')}
+  ];
+  result = Analyzer.computeColMeta(arr);
+  assert.equal(result[0].type, 'DATE_OBJECT', 'Interprets invalid Dates as date objects');
+
   assert.end();
 });
 /* eslint-enable max-statements*/


### PR DESCRIPTION
Updating from internal `type-analyzer` to OSS version caused breakages in internal tools (in test, though possibly also in prod) as the internal version returns `NUMBER` for `Date` inputs, while the OSS version returns `OBJECT`.

Rather than try to rearrange things so that `Date`s end up as `NUMBER`s, I opted instead for a non-breaking, additive change: `Date` inputs now return a new `DATE_OBJECT` type, which seems in keeping with the support for `ARRAY` and `OBJECT` present in the OSS version but not in the internal version.

I plan to release as a minor (`0.3.0`) -- this is a breaking change for any consumers expecting `Date`s to return `OBJECT`.